### PR TITLE
Add custom cache directory option

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -62,6 +62,7 @@ module.exports = (eleventyConfig, options = {}) => {
         {
           duration: options.duration || "1m",
           type: "json",
+          directory: options.directory || ".cache",
         }
       );
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,21 @@ Turn URLs into rich cards. Show a preview image, page title, description and oth
    const pluginUnfurl = require("eleventy-plugin-unfurl");
    ```
 
-2. Install the demo dependencies:
+2. Install the module dependencies:
 
-   ```text
+   ```bash
+   npm install
+   ```
+
+3. Install the demo dependencies:
+
+   ```bash
    cd demo
    npm install
    ```
 
-3. Run the demo locally:
-   ```text
+4. Run the demo locally:
+   ```bash
    npm run dev
    ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Turn URLs into rich cards. Show a preview image, page title, description and oth
 
 - `duration`: The duration of time before the cache is busted and new data is captured from the URL. Default is `1m`, check out the [Eleventy Fetch documentation for more info](https://www.11ty.dev/docs/plugins/fetch/#change-the-cache-duration).
 
+- `directory`: Set a cache directory. Default is `.cache`, check out the [Eleventy Fetch documentation for more info](https://www.11ty.dev/docs/plugins/fetch/#cache-directory).
+
 - `template`: A custom template to present unfurled links. Can be a totally custom HTML template string.
 
   Example:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-unfurl",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Unfurl links into preview cards in Eleventy",
   "homepage": "https://github.com/daviddarnes/eleventy-plugin-unfurl",
   "main": ".eleventy.js",


### PR DESCRIPTION
- Add an option for a custom cache directory with `directory` as an option
- Updated readme to include this option
- Bumped the version to 1.0.1
- Bonus: updated readme to include steps of `rpm install` in the root for development